### PR TITLE
identified the eshop lock bits

### DIFF
--- a/country_list/country.json
+++ b/country_list/country.json
@@ -33,7 +33,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         }
       ],
       "countriesPatch": [
@@ -69,8 +70,7 @@
             0
           ]
         }
-      ],
-      "tail": "00 00 00 00"
+      ]
     },
     {
       "region": "EU",
@@ -105,7 +105,8 @@
             1,
             3,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 66,
@@ -137,7 +138,8 @@
             5,
             1,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 67,
@@ -169,7 +171,8 @@
             7,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 68,
@@ -201,7 +204,8 @@
             8,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 69,
@@ -233,7 +237,8 @@
             9,
             8,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 70,
@@ -265,7 +270,8 @@
             10,
             6,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 71,
@@ -297,7 +303,8 @@
             13,
             58,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 72,
@@ -329,7 +336,8 @@
             12,
             26,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 73,
@@ -361,7 +369,8 @@
             53,
             61,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 74,
@@ -393,7 +402,8 @@
             14,
             16,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 75,
@@ -425,7 +435,8 @@
             20,
             65,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 76,
@@ -457,7 +468,8 @@
             21,
             56,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 77,
@@ -489,7 +501,8 @@
             22,
             57,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 78,
@@ -521,7 +534,8 @@
             2,
             12,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 79,
@@ -553,7 +567,8 @@
             24,
             15,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 80,
@@ -585,7 +600,8 @@
             26,
             11,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 81,
@@ -617,7 +633,8 @@
             30,
             23,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 82,
@@ -649,7 +666,8 @@
             29,
             22,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 83,
@@ -681,7 +699,8 @@
             31,
             25,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 84,
@@ -713,7 +732,8 @@
             34,
             27,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 85,
@@ -745,7 +765,8 @@
             33,
             28,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 86,
@@ -777,7 +798,8 @@
             35,
             30,
             32
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 87,
@@ -809,7 +831,8 @@
             36,
             29,
             33
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 88,
@@ -841,7 +864,8 @@
             37,
             31,
             34
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 89,
@@ -873,7 +897,8 @@
             38,
             33,
             35
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 90,
@@ -905,7 +930,8 @@
             40,
             35,
             37
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 91,
@@ -937,7 +963,8 @@
             44,
             60,
             40
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 92,
@@ -969,7 +996,8 @@
             42,
             36,
             41
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 93,
@@ -1001,7 +1029,8 @@
             45,
             39,
             42
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 94,
@@ -1033,7 +1062,8 @@
             49,
             41,
             43
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 96,
@@ -1065,7 +1095,8 @@
             47,
             43,
             46
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 97,
@@ -1097,7 +1128,8 @@
             50,
             44,
             47
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 98,
@@ -1129,7 +1161,8 @@
             51,
             45,
             48
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 99,
@@ -1161,7 +1194,8 @@
             54,
             47,
             49
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 100,
@@ -1193,7 +1227,8 @@
             55,
             46,
             50
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 101,
@@ -1225,7 +1260,8 @@
             57,
             50,
             52
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 102,
@@ -1257,7 +1293,8 @@
             17,
             51,
             53
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 103,
@@ -1289,7 +1326,8 @@
             18,
             52,
             54
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 104,
@@ -1321,7 +1359,8 @@
             0,
             66,
             56
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 105,
@@ -1353,7 +1392,8 @@
             19,
             24,
             57
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 106,
@@ -1385,7 +1425,8 @@
             59,
             49,
             59
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 107,
@@ -1417,7 +1458,8 @@
             61,
             63,
             60
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 108,
@@ -1449,7 +1491,8 @@
             62,
             62,
             61
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 109,
@@ -1481,7 +1524,8 @@
             63,
             55,
             62
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 110,
@@ -1513,7 +1557,8 @@
             52,
             10,
             63
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 111,
@@ -1545,7 +1590,8 @@
             65,
             19,
             65
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 112,
@@ -1577,7 +1623,8 @@
             66,
             20,
             66
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 113,
@@ -1609,7 +1656,8 @@
             6,
             2,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 114,
@@ -1641,7 +1689,8 @@
             41,
             32,
             38
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 115,
@@ -1673,7 +1722,8 @@
             39,
             34,
             36
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 116,
@@ -1705,7 +1755,8 @@
             46,
             40,
             45
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 117,
@@ -1737,7 +1788,8 @@
             11,
             59,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 118,
@@ -1769,7 +1821,8 @@
             60,
             54,
             58
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 119,
@@ -1801,7 +1854,8 @@
             16,
             64,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 120,
@@ -1833,7 +1887,8 @@
             15,
             18,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 121,
@@ -1865,7 +1920,8 @@
             58,
             53,
             55
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 122,
@@ -1897,7 +1953,8 @@
             3,
             4,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 123,
@@ -1929,7 +1986,8 @@
             23,
             14,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 124,
@@ -1961,7 +2019,8 @@
             25,
             13,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 125,
@@ -1993,7 +2052,8 @@
             27,
             38,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 126,
@@ -2025,7 +2085,8 @@
             32,
             17,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 127,
@@ -2057,7 +2118,8 @@
             43,
             37,
             39
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 169,
@@ -2089,7 +2151,8 @@
             28,
             21,
             25
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "country": 184,
@@ -2121,7 +2184,8 @@
             56,
             48,
             51
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 185,
@@ -2153,7 +2217,8 @@
             64,
             9,
             64
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 65,
@@ -2185,7 +2250,8 @@
             4,
             0,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 95,
@@ -2217,7 +2283,8 @@
             48,
             42,
             44
-          ]
+          ],
+          "eshopLock": false
         }
       ],
       "countriesPatch": [
@@ -2285,8 +2352,7 @@
             63
           ]
         }
-      ],
-      "tail": "00 00 00 00 00 00 00 40 00 00 00 00"
+      ]
     },
     {
       "region": "JP",
@@ -2321,11 +2387,11 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "countriesPatch": [],
-      "tail": "00 00 00 00"
+      "countriesPatch": []
     },
     {
       "region": "KR",
@@ -2360,11 +2426,11 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "countriesPatch": [],
-      "tail": "00 00 00 00"
+      "countriesPatch": []
     },
     {
       "region": "TW",
@@ -2399,7 +2465,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 144,
@@ -2431,7 +2498,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
       "countriesPatch": [
@@ -2499,8 +2567,7 @@
             2
           ]
         }
-      ],
-      "tail": "00 00 00 00"
+      ]
     },
     {
       "region": "US",
@@ -2535,7 +2602,8 @@
             0,
             1,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 9,
@@ -2567,7 +2635,8 @@
             1,
             2,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 10,
@@ -2599,7 +2668,8 @@
             4,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 11,
@@ -2631,7 +2701,8 @@
             5,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 12,
@@ -2663,7 +2734,8 @@
             6,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 13,
@@ -2695,7 +2767,8 @@
             7,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 14,
@@ -2727,7 +2800,8 @@
             8,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 15,
@@ -2759,7 +2833,8 @@
             10,
             9,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 16,
@@ -2791,7 +2866,8 @@
             11,
             10,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 17,
@@ -2823,7 +2899,8 @@
             31,
             11,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 18,
@@ -2855,7 +2932,8 @@
             12,
             22,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 19,
@@ -2887,7 +2965,8 @@
             28,
             21,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 20,
@@ -2919,7 +2998,8 @@
             13,
             47,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 21,
@@ -2951,7 +3031,8 @@
             14,
             23,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 22,
@@ -2983,7 +3064,8 @@
             15,
             24,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 23,
@@ -3015,7 +3097,8 @@
             16,
             19,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 24,
@@ -3047,7 +3130,8 @@
             41,
             20,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 25,
@@ -3079,7 +3163,8 @@
             19,
             48,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 26,
@@ -3111,7 +3196,8 @@
             17,
             35,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 27,
@@ -3143,7 +3229,8 @@
             25,
             46,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 28,
@@ -3175,7 +3262,8 @@
             21,
             18,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 29,
@@ -3207,7 +3295,8 @@
             22,
             15,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 30,
@@ -3239,7 +3328,8 @@
             23,
             16,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 31,
@@ -3271,7 +3361,8 @@
             24,
             13,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 32,
@@ -3303,7 +3394,8 @@
             26,
             14,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 33,
@@ -3335,7 +3427,8 @@
             27,
             17,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 34,
@@ -3367,7 +3460,8 @@
             32,
             49,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 35,
@@ -3399,7 +3493,8 @@
             34,
             26,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 36,
@@ -3431,7 +3526,8 @@
             35,
             27,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 37,
@@ -3463,7 +3559,8 @@
             36,
             28,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 38,
@@ -3495,7 +3592,8 @@
             2,
             29,
             32
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 39,
@@ -3527,7 +3625,8 @@
             37,
             30,
             33
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 40,
@@ -3559,7 +3658,8 @@
             38,
             32,
             34
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 41,
@@ -3591,7 +3691,8 @@
             39,
             33,
             35
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 42,
@@ -3623,7 +3724,8 @@
             40,
             34,
             36
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 43,
@@ -3655,7 +3757,8 @@
             44,
             38,
             39
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 44,
@@ -3687,7 +3790,8 @@
             43,
             39,
             40
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 45,
@@ -3719,7 +3823,8 @@
             42,
             37,
             41
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 46,
@@ -3751,7 +3856,8 @@
             46,
             42,
             42
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 47,
@@ -3783,7 +3889,8 @@
             47,
             44,
             43
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 48,
@@ -3815,7 +3922,8 @@
             29,
             43,
             44
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 49,
@@ -3847,7 +3955,8 @@
             20,
             41,
             46
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 50,
@@ -3879,7 +3988,8 @@
             48,
             45,
             47
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 51,
@@ -3911,7 +4021,8 @@
             30,
             0,
             48
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 52,
@@ -3943,7 +4054,8 @@
             49,
             12,
             49
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 153,
@@ -3975,7 +4087,8 @@
             45,
             40,
             38
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 156,
@@ -4007,7 +4120,8 @@
             33,
             25,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 168,
@@ -4039,7 +4153,8 @@
             18,
             31,
             45
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 174,
@@ -4071,7 +4186,8 @@
             3,
             36,
             37
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "country": 186,
@@ -4103,11 +4219,11 @@
             9,
             8,
             7
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "countriesPatch": [],
-      "tail": "00 00 00 00 00 00 00 00"
+      "countriesPatch": []
     }
   ],
   "countries": [
@@ -4160,7 +4276,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -4207,7 +4324,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -4254,7 +4372,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -4301,7 +4420,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -4348,7 +4468,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -4395,7 +4516,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -4442,7 +4564,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -4489,7 +4612,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -4536,7 +4660,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -4583,7 +4708,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -4630,7 +4756,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -4677,7 +4804,8 @@
             11,
             11,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -4724,7 +4852,8 @@
             12,
             12,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -4771,7 +4900,8 @@
             13,
             13,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -4818,7 +4948,8 @@
             14,
             14,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -4865,7 +4996,8 @@
             15,
             15,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -4912,7 +5044,8 @@
             16,
             16,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -4959,7 +5092,8 @@
             17,
             17,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -5006,7 +5140,8 @@
             18,
             18,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -5053,7 +5188,8 @@
             19,
             19,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -5100,7 +5236,8 @@
             20,
             20,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -5147,7 +5284,8 @@
             21,
             21,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -5194,7 +5332,8 @@
             22,
             22,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -5241,7 +5380,8 @@
             23,
             23,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -5288,7 +5428,8 @@
             24,
             24,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -5335,7 +5476,8 @@
             25,
             25,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -5382,7 +5524,8 @@
             26,
             26,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -5429,7 +5572,8 @@
             27,
             27,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -5476,7 +5620,8 @@
             28,
             28,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -5523,7 +5668,8 @@
             29,
             29,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -5570,7 +5716,8 @@
             30,
             30,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -5617,7 +5764,8 @@
             31,
             31,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -5664,7 +5812,8 @@
             32,
             32,
             32
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 34,
@@ -5711,7 +5860,8 @@
             33,
             33,
             33
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 35,
@@ -5758,7 +5908,8 @@
             34,
             34,
             34
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 36,
@@ -5805,7 +5956,8 @@
             35,
             35,
             35
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 37,
@@ -5852,7 +6004,8 @@
             36,
             36,
             36
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 38,
@@ -5899,7 +6052,8 @@
             37,
             37,
             37
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 39,
@@ -5946,7 +6100,8 @@
             38,
             38,
             38
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 40,
@@ -5993,7 +6148,8 @@
             39,
             39,
             39
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 41,
@@ -6040,7 +6196,8 @@
             40,
             40,
             40
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 42,
@@ -6087,7 +6244,8 @@
             41,
             41,
             41
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 43,
@@ -6134,7 +6292,8 @@
             42,
             42,
             42
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 44,
@@ -6181,7 +6340,8 @@
             43,
             43,
             43
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 45,
@@ -6228,7 +6388,8 @@
             44,
             44,
             44
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 46,
@@ -6275,7 +6436,8 @@
             45,
             45,
             45
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 47,
@@ -6322,7 +6484,8 @@
             46,
             46,
             46
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 48,
@@ -6369,11 +6532,11 @@
             47,
             47,
             47
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00 00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 8,
@@ -6424,7 +6587,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -6471,11 +6635,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 9,
@@ -6526,7 +6690,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -6573,7 +6738,8 @@
             3,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -6620,7 +6786,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -6667,7 +6834,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -6714,7 +6882,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -6761,7 +6930,8 @@
             5,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -6808,7 +6978,8 @@
             6,
             5,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -6855,11 +7026,11 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 10,
@@ -6910,7 +7081,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -6957,7 +7129,8 @@
             7,
             20,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -7004,7 +7177,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -7051,7 +7225,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -7098,7 +7273,8 @@
             3,
             22,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -7145,7 +7321,8 @@
             4,
             23,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -7192,7 +7369,8 @@
             5,
             4,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -7239,7 +7417,8 @@
             6,
             5,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -7286,7 +7465,8 @@
             8,
             24,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -7333,7 +7513,8 @@
             9,
             21,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -7380,7 +7561,8 @@
             10,
             2,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -7427,7 +7609,8 @@
             11,
             6,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -7474,7 +7657,8 @@
             12,
             7,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -7521,7 +7705,8 @@
             13,
             8,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -7568,7 +7753,8 @@
             14,
             9,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -7615,7 +7801,8 @@
             15,
             10,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -7662,7 +7849,8 @@
             16,
             12,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -7709,7 +7897,8 @@
             17,
             13,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -7756,7 +7945,8 @@
             18,
             15,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -7803,7 +7993,8 @@
             19,
             14,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -7850,7 +8041,8 @@
             20,
             16,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -7897,7 +8089,8 @@
             21,
             17,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -7944,7 +8137,8 @@
             22,
             18,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -7991,7 +8185,8 @@
             23,
             11,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -8038,11 +8233,11 @@
             24,
             19,
             24
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 11,
@@ -8093,7 +8288,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -8140,11 +8336,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 12,
@@ -8195,7 +8391,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -8242,11 +8439,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 13,
@@ -8297,7 +8494,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -8344,11 +8542,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 14,
@@ -8399,7 +8597,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -8446,7 +8645,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -8493,7 +8693,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -8540,7 +8741,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -8587,7 +8789,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -8634,7 +8837,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -8681,11 +8885,11 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 15,
@@ -8736,7 +8940,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -8783,7 +8988,8 @@
             4,
             3,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -8830,7 +9036,8 @@
             1,
             9,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -8877,7 +9084,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -8924,7 +9132,8 @@
             3,
             1,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -8971,7 +9180,8 @@
             5,
             4,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -9018,7 +9228,8 @@
             6,
             5,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -9065,7 +9276,8 @@
             7,
             6,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -9112,7 +9324,8 @@
             8,
             7,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -9159,11 +9372,11 @@
             9,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 16,
@@ -9214,7 +9427,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -9261,7 +9475,8 @@
             7,
             26,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -9308,7 +9523,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -9355,7 +9571,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -9402,7 +9619,8 @@
             3,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -9449,7 +9667,8 @@
             4,
             3,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -9496,7 +9715,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -9543,7 +9763,8 @@
             6,
             23,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -9590,7 +9811,8 @@
             8,
             27,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -9637,7 +9859,8 @@
             12,
             9,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -9684,7 +9907,8 @@
             10,
             7,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -9731,7 +9955,8 @@
             11,
             8,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -9778,7 +10003,8 @@
             13,
             10,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -9825,7 +10051,8 @@
             14,
             11,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -9872,7 +10099,8 @@
             15,
             12,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -9919,7 +10147,8 @@
             16,
             13,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -9966,7 +10195,8 @@
             18,
             15,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -10013,7 +10243,8 @@
             19,
             16,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -10060,7 +10291,8 @@
             20,
             17,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -10107,7 +10339,8 @@
             21,
             18,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -10154,7 +10387,8 @@
             22,
             19,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -10201,7 +10435,8 @@
             23,
             20,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -10248,7 +10483,8 @@
             24,
             22,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -10295,7 +10531,8 @@
             25,
             21,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -10342,7 +10579,8 @@
             26,
             24,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -10389,7 +10627,8 @@
             9,
             6,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -10436,7 +10675,8 @@
             17,
             14,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -10483,11 +10723,11 @@
             27,
             25,
             27
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 17,
@@ -10538,7 +10778,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -10585,11 +10826,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 18,
@@ -10640,7 +10881,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -10687,7 +10929,8 @@
             8,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -10734,7 +10977,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -10781,7 +11025,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -10828,7 +11073,8 @@
             4,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -10875,7 +11121,8 @@
             5,
             7,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -10922,7 +11169,8 @@
             11,
             8,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -10969,7 +11217,8 @@
             6,
             5,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -11016,7 +11265,8 @@
             3,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -11063,7 +11313,8 @@
             9,
             3,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -11110,7 +11361,8 @@
             10,
             11,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -11157,7 +11409,8 @@
             13,
             13,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -11204,7 +11457,8 @@
             12,
             12,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -11251,11 +11505,11 @@
             7,
             6,
             8
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 19,
@@ -11306,7 +11560,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -11353,11 +11608,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 20,
@@ -11408,7 +11663,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -11455,7 +11711,8 @@
             11,
             12,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -11502,7 +11759,8 @@
             13,
             6,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -11549,7 +11807,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -11596,7 +11855,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -11643,7 +11903,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -11690,7 +11951,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -11737,7 +11999,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -11784,7 +12047,8 @@
             6,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -11831,7 +12095,8 @@
             7,
             11,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -11878,7 +12143,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -11925,7 +12191,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -11972,7 +12239,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -12019,11 +12287,11 @@
             12,
             13,
             12
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 21,
@@ -12074,7 +12342,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -12121,7 +12390,8 @@
             16,
             29,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -12168,7 +12438,8 @@
             15,
             19,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -12215,7 +12486,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -12262,7 +12534,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -12309,7 +12582,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -12356,7 +12630,8 @@
             5,
             4,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -12403,7 +12678,8 @@
             6,
             5,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -12450,7 +12726,8 @@
             7,
             6,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -12497,7 +12774,8 @@
             8,
             14,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -12544,7 +12822,8 @@
             9,
             13,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -12591,7 +12870,8 @@
             11,
             16,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -12638,7 +12918,8 @@
             12,
             28,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -12685,7 +12966,8 @@
             13,
             33,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -12732,7 +13014,8 @@
             14,
             18,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -12779,7 +13062,8 @@
             18,
             10,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -12826,7 +13110,8 @@
             17,
             11,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -12873,7 +13158,8 @@
             19,
             32,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -12920,7 +13206,8 @@
             20,
             12,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -12967,7 +13254,8 @@
             21,
             20,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -13014,7 +13302,8 @@
             22,
             21,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -13061,7 +13350,8 @@
             23,
             22,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -13108,7 +13398,8 @@
             24,
             23,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -13155,7 +13446,8 @@
             25,
             24,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -13202,7 +13494,8 @@
             26,
             17,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -13249,7 +13542,8 @@
             27,
             25,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -13296,7 +13590,8 @@
             4,
             26,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -13343,7 +13638,8 @@
             28,
             27,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -13390,7 +13686,8 @@
             29,
             30,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -13437,7 +13734,8 @@
             30,
             31,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -13484,7 +13782,8 @@
             31,
             7,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -13531,7 +13830,8 @@
             32,
             8,
             32
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -13578,7 +13878,8 @@
             33,
             9,
             33
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 34,
@@ -13625,11 +13926,11 @@
             10,
             15,
             10
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00 00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 22,
@@ -13680,7 +13981,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -13727,7 +14029,8 @@
             7,
             6,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -13774,7 +14077,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -13821,7 +14125,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -13868,7 +14173,8 @@
             3,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -13915,7 +14221,8 @@
             4,
             7,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -13962,7 +14269,8 @@
             5,
             4,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -14009,11 +14317,11 @@
             6,
             5,
             6
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 23,
@@ -14064,7 +14372,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -14111,11 +14420,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 24,
@@ -14166,7 +14475,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -14213,7 +14523,8 @@
             5,
             15,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -14260,7 +14571,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -14307,7 +14619,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -14354,7 +14667,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -14401,7 +14715,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -14448,7 +14763,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -14495,7 +14811,8 @@
             9,
             30,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -14542,7 +14859,8 @@
             11,
             7,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -14589,7 +14907,8 @@
             12,
             8,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -14636,7 +14955,8 @@
             8,
             29,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -14683,7 +15003,8 @@
             13,
             10,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -14730,7 +15051,8 @@
             15,
             11,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -14777,7 +15099,8 @@
             17,
             13,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -14824,7 +15147,8 @@
             19,
             16,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -14871,7 +15195,8 @@
             20,
             17,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -14918,7 +15243,8 @@
             21,
             18,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -14965,7 +15291,8 @@
             22,
             19,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -15012,7 +15339,8 @@
             23,
             20,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -15059,7 +15387,8 @@
             26,
             26,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -15106,7 +15435,8 @@
             24,
             23,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -15153,7 +15483,8 @@
             25,
             22,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -15200,7 +15531,8 @@
             27,
             24,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -15247,7 +15579,8 @@
             28,
             25,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -15294,7 +15627,8 @@
             30,
             4,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -15341,7 +15675,8 @@
             7,
             28,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -15388,7 +15723,8 @@
             10,
             27,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -15435,7 +15771,8 @@
             14,
             9,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -15482,7 +15819,8 @@
             16,
             12,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -15529,7 +15867,8 @@
             18,
             14,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -15576,11 +15915,11 @@
             29,
             21,
             24
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 25,
@@ -15631,7 +15970,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -15678,7 +16018,8 @@
             19,
             16,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -15725,7 +16066,8 @@
             9,
             3,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -15772,7 +16114,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -15819,7 +16162,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -15866,7 +16210,8 @@
             3,
             6,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -15913,7 +16258,8 @@
             4,
             7,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -15960,7 +16306,8 @@
             5,
             22,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -16007,7 +16354,8 @@
             6,
             8,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -16054,7 +16402,8 @@
             7,
             23,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -16101,7 +16450,8 @@
             8,
             24,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -16148,7 +16498,8 @@
             10,
             4,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -16195,7 +16546,8 @@
             11,
             5,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -16242,7 +16594,8 @@
             12,
             10,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -16289,7 +16642,8 @@
             13,
             9,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -16336,7 +16690,8 @@
             14,
             11,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -16383,7 +16738,8 @@
             15,
             12,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -16430,7 +16786,8 @@
             18,
             15,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -16477,7 +16834,8 @@
             23,
             21,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -16524,7 +16882,8 @@
             24,
             17,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -16571,7 +16930,8 @@
             22,
             20,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -16618,7 +16978,8 @@
             16,
             13,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -16665,7 +17026,8 @@
             17,
             14,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -16712,7 +17074,8 @@
             20,
             18,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -16759,11 +17122,11 @@
             21,
             19,
             21
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 26,
@@ -16814,7 +17177,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -16861,7 +17225,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -16908,7 +17273,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -16955,7 +17321,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -17002,7 +17369,8 @@
             3,
             14,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -17049,7 +17417,8 @@
             4,
             3,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -17096,7 +17465,8 @@
             5,
             4,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -17143,7 +17513,8 @@
             6,
             5,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -17190,7 +17561,8 @@
             7,
             6,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -17237,7 +17609,8 @@
             8,
             7,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -17284,7 +17657,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -17331,7 +17705,8 @@
             12,
             11,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -17378,7 +17753,8 @@
             11,
             8,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -17425,7 +17801,8 @@
             13,
             12,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -17472,11 +17849,11 @@
             14,
             13,
             14
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 27,
@@ -17527,7 +17904,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -17574,11 +17952,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 28,
@@ -17629,7 +18007,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -17676,11 +18055,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 29,
@@ -17731,7 +18110,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -17778,11 +18158,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 30,
@@ -17833,7 +18213,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -17880,7 +18261,8 @@
             7,
             3,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -17927,7 +18309,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -17974,7 +18357,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -18021,7 +18405,8 @@
             3,
             20,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -18068,7 +18453,8 @@
             4,
             19,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -18115,7 +18501,8 @@
             5,
             21,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -18162,7 +18549,8 @@
             6,
             22,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -18209,7 +18597,8 @@
             8,
             16,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -18256,7 +18645,8 @@
             9,
             4,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -18303,7 +18693,8 @@
             10,
             17,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -18350,7 +18741,8 @@
             11,
             18,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -18397,7 +18789,8 @@
             12,
             7,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -18444,7 +18837,8 @@
             13,
             5,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -18491,7 +18885,8 @@
             14,
             6,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -18538,7 +18933,8 @@
             15,
             8,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -18585,7 +18981,8 @@
             16,
             10,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -18632,7 +19029,8 @@
             17,
             11,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -18679,7 +19077,8 @@
             18,
             12,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -18726,7 +19125,8 @@
             19,
             13,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -18773,7 +19173,8 @@
             20,
             14,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -18820,7 +19221,8 @@
             21,
             15,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -18867,11 +19269,11 @@
             22,
             9,
             22
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 31,
@@ -18922,7 +19324,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -18969,7 +19372,8 @@
             6,
             5,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -19016,7 +19420,8 @@
             3,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -19063,7 +19468,8 @@
             5,
             6,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -19110,7 +19516,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -19157,7 +19564,8 @@
             7,
             10,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -19204,7 +19612,8 @@
             8,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -19251,7 +19660,8 @@
             9,
             8,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -19298,7 +19708,8 @@
             10,
             9,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -19345,7 +19756,8 @@
             1,
             2,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -19392,11 +19804,11 @@
             2,
             3,
             10
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 32,
@@ -19447,7 +19859,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -19494,7 +19907,8 @@
             8,
             3,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -19541,7 +19955,8 @@
             6,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -19588,7 +20003,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -19635,7 +20051,8 @@
             2,
             8,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -19682,7 +20099,8 @@
             3,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -19729,7 +20147,8 @@
             7,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -19776,7 +20195,8 @@
             5,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -19823,7 +20243,8 @@
             10,
             10,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -19870,7 +20291,8 @@
             9,
             9,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -19917,11 +20339,11 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 33,
@@ -19972,7 +20394,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -20019,7 +20442,8 @@
             8,
             16,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -20066,7 +20490,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -20113,7 +20538,8 @@
             2,
             17,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -20160,7 +20586,8 @@
             3,
             8,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -20207,7 +20634,8 @@
             4,
             7,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -20254,7 +20682,8 @@
             5,
             9,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -20301,7 +20730,8 @@
             6,
             10,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -20348,7 +20778,8 @@
             7,
             18,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -20395,7 +20826,8 @@
             9,
             3,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -20442,7 +20874,8 @@
             10,
             4,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -20489,7 +20922,8 @@
             11,
             6,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -20536,7 +20970,8 @@
             12,
             11,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -20583,7 +21018,8 @@
             13,
             12,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -20630,7 +21066,8 @@
             14,
             13,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -20677,7 +21114,8 @@
             15,
             14,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -20724,7 +21162,8 @@
             16,
             15,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -20771,7 +21210,8 @@
             17,
             2,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -20818,11 +21258,11 @@
             18,
             5,
             18
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 34,
@@ -20873,7 +21313,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -20920,7 +21361,8 @@
             12,
             8,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -20967,7 +21409,8 @@
             1,
             2,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -21014,7 +21457,8 @@
             2,
             14,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -21061,7 +21505,8 @@
             4,
             3,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -21108,7 +21553,8 @@
             5,
             4,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -21155,7 +21601,8 @@
             6,
             10,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -21202,7 +21649,8 @@
             7,
             11,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -21249,7 +21697,8 @@
             8,
             6,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -21296,7 +21745,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -21343,7 +21793,8 @@
             10,
             5,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -21390,7 +21841,8 @@
             11,
             7,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -21437,7 +21889,8 @@
             13,
             12,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -21484,7 +21937,8 @@
             14,
             13,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -21531,11 +21985,11 @@
             3,
             1,
             3
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 35,
@@ -21586,7 +22040,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -21633,11 +22088,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 36,
@@ -21688,7 +22143,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -21735,7 +22191,8 @@
             9,
             27,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -21782,7 +22239,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -21829,7 +22287,8 @@
             2,
             16,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -21876,7 +22335,8 @@
             3,
             31,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -21923,7 +22383,8 @@
             4,
             7,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -21970,7 +22431,8 @@
             5,
             30,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -22017,7 +22479,8 @@
             6,
             29,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -22064,7 +22527,8 @@
             7,
             10,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -22111,7 +22575,8 @@
             8,
             11,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -22158,7 +22623,8 @@
             10,
             5,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -22205,7 +22671,8 @@
             11,
             4,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -22252,7 +22719,8 @@
             12,
             3,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -22299,7 +22767,8 @@
             13,
             6,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -22346,7 +22815,8 @@
             14,
             28,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -22393,7 +22863,8 @@
             15,
             12,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -22440,7 +22911,8 @@
             16,
             13,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -22487,7 +22959,8 @@
             17,
             14,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -22534,7 +23007,8 @@
             18,
             15,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -22581,7 +23055,8 @@
             19,
             17,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -22628,7 +23103,8 @@
             20,
             18,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -22675,7 +23151,8 @@
             21,
             19,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -22722,7 +23199,8 @@
             22,
             8,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -22769,7 +23247,8 @@
             23,
             9,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -22816,7 +23295,8 @@
             24,
             21,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -22863,7 +23343,8 @@
             25,
             22,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -22910,7 +23391,8 @@
             26,
             23,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -22957,7 +23439,8 @@
             27,
             24,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -23004,7 +23487,8 @@
             28,
             25,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -23051,7 +23535,8 @@
             29,
             26,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -23098,7 +23583,8 @@
             30,
             2,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -23145,7 +23631,8 @@
             31,
             32,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -23192,11 +23679,11 @@
             32,
             20,
             32
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00 00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 37,
@@ -23247,7 +23734,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -23294,11 +23782,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 38,
@@ -23349,7 +23837,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -23396,11 +23885,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 39,
@@ -23451,7 +23940,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -23498,7 +23988,8 @@
             12,
             8,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -23545,7 +24036,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -23592,7 +24084,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -23639,7 +24132,8 @@
             5,
             15,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -23686,7 +24180,8 @@
             6,
             16,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -23733,7 +24228,8 @@
             7,
             17,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -23780,7 +24276,8 @@
             8,
             4,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -23827,7 +24324,8 @@
             9,
             14,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -23874,7 +24372,8 @@
             10,
             6,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -23921,7 +24420,8 @@
             11,
             7,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -23968,7 +24468,8 @@
             13,
             9,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -24015,7 +24516,8 @@
             14,
             10,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -24062,7 +24564,8 @@
             15,
             11,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -24109,7 +24612,8 @@
             16,
             13,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -24156,7 +24660,8 @@
             17,
             12,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -24203,7 +24708,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -24250,11 +24756,11 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 40,
@@ -24305,7 +24811,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -24352,7 +24859,8 @@
             9,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -24399,7 +24907,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -24446,7 +24955,8 @@
             2,
             9,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -24493,7 +25003,8 @@
             3,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -24540,7 +25051,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -24587,7 +25099,8 @@
             5,
             3,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -24634,7 +25147,8 @@
             6,
             10,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -24681,7 +25195,8 @@
             8,
             7,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -24728,7 +25243,8 @@
             7,
             6,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -24775,11 +25291,11 @@
             10,
             2,
             10
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 41,
@@ -24830,7 +25346,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -24877,7 +25394,8 @@
             9,
             18,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -24924,7 +25442,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -24971,7 +25490,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -25018,7 +25538,8 @@
             6,
             8,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -25065,7 +25586,8 @@
             7,
             9,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -25112,7 +25634,8 @@
             10,
             11,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -25159,7 +25682,8 @@
             11,
             12,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -25206,7 +25730,8 @@
             12,
             6,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -25253,7 +25778,8 @@
             13,
             7,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -25300,7 +25826,8 @@
             14,
             13,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -25347,7 +25874,8 @@
             15,
             14,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -25394,7 +25922,8 @@
             16,
             15,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -25441,7 +25970,8 @@
             17,
             16,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -25488,7 +26018,8 @@
             18,
             17,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -25535,7 +26066,8 @@
             8,
             10,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -25582,7 +26114,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -25629,7 +26162,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -25676,11 +26210,11 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 42,
@@ -25731,7 +26265,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -25778,7 +26313,8 @@
             15,
             12,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -25825,7 +26361,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -25872,7 +26409,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -25919,7 +26457,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -25966,7 +26505,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -26013,7 +26553,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -26060,7 +26601,8 @@
             6,
             8,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -26107,7 +26649,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -26154,7 +26697,8 @@
             8,
             9,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -26201,7 +26745,8 @@
             9,
             22,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -26248,7 +26793,8 @@
             10,
             23,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -26295,7 +26841,8 @@
             11,
             6,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -26342,7 +26889,8 @@
             12,
             25,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -26389,7 +26937,8 @@
             13,
             10,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -26436,7 +26985,8 @@
             14,
             11,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -26483,7 +27033,8 @@
             16,
             13,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -26530,7 +27081,8 @@
             17,
             14,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -26577,7 +27129,8 @@
             18,
             15,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -26624,7 +27177,8 @@
             19,
             16,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -26671,7 +27225,8 @@
             20,
             17,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -26718,7 +27273,8 @@
             21,
             18,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -26765,7 +27321,8 @@
             22,
             19,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -26812,7 +27369,8 @@
             23,
             20,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -26859,7 +27417,8 @@
             24,
             21,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -26906,11 +27465,11 @@
             25,
             24,
             25
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 43,
@@ -26961,7 +27520,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -27008,7 +27568,8 @@
             3,
             5,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -27055,7 +27616,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -27102,7 +27664,8 @@
             2,
             13,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -27149,7 +27712,8 @@
             4,
             6,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -27196,7 +27760,8 @@
             5,
             2,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -27243,7 +27808,8 @@
             6,
             3,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -27290,7 +27856,8 @@
             7,
             4,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -27337,7 +27904,8 @@
             8,
             7,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -27384,7 +27952,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -27431,7 +28000,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -27478,7 +28048,8 @@
             11,
             8,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -27525,7 +28096,8 @@
             12,
             11,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -27572,7 +28144,8 @@
             13,
             12,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -27619,11 +28192,11 @@
             14,
             14,
             14
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 44,
@@ -27674,7 +28247,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -27721,11 +28295,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 45,
@@ -27776,7 +28350,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -27823,11 +28398,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 46,
@@ -27878,7 +28453,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -27925,7 +28501,8 @@
             7,
             8,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -27972,7 +28549,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -28019,7 +28597,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -28066,7 +28645,8 @@
             3,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -28113,7 +28693,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -28160,7 +28741,8 @@
             5,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -28207,7 +28789,8 @@
             6,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -28254,7 +28837,8 @@
             8,
             9,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -28301,7 +28885,8 @@
             9,
             10,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -28348,11 +28933,11 @@
             10,
             2,
             10
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 47,
@@ -28403,7 +28988,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -28450,7 +29036,8 @@
             6,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -28497,7 +29084,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -28544,7 +29132,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -28591,7 +29180,8 @@
             3,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -28638,7 +29228,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -28685,7 +29276,8 @@
             7,
             12,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -28732,7 +29324,8 @@
             8,
             10,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -28779,7 +29372,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -28826,7 +29420,8 @@
             10,
             11,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -28873,7 +29468,8 @@
             11,
             8,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -28920,7 +29516,8 @@
             12,
             13,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -28967,7 +29564,8 @@
             13,
             2,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -29014,11 +29612,11 @@
             5,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 48,
@@ -29069,7 +29667,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -29116,11 +29715,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 49,
@@ -29171,7 +29770,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -29218,7 +29818,8 @@
             13,
             40,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -29265,7 +29866,8 @@
             2,
             4,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -29312,7 +29914,8 @@
             1,
             3,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -29359,7 +29962,8 @@
             4,
             6,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -29406,7 +30010,8 @@
             3,
             5,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -29453,7 +30058,8 @@
             5,
             18,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -29500,7 +30106,8 @@
             8,
             21,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -29547,7 +30154,8 @@
             9,
             22,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -29594,7 +30202,8 @@
             12,
             13,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -29641,7 +30250,8 @@
             14,
             49,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -29688,7 +30298,8 @@
             15,
             14,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -29735,7 +30346,8 @@
             16,
             12,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -29782,7 +30394,8 @@
             20,
             2,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -29829,7 +30442,8 @@
             17,
             1,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -29876,7 +30490,8 @@
             18,
             16,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -29923,7 +30538,8 @@
             19,
             17,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -29970,7 +30586,8 @@
             21,
             19,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -30017,7 +30634,8 @@
             22,
             20,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -30064,7 +30682,8 @@
             23,
             23,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -30111,7 +30730,8 @@
             26,
             24,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -30158,7 +30778,8 @@
             25,
             31,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -30205,7 +30826,8 @@
             24,
             30,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -30252,7 +30874,8 @@
             27,
             28,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -30299,7 +30922,8 @@
             28,
             25,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -30346,7 +30970,8 @@
             30,
             27,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -30393,7 +31018,8 @@
             29,
             26,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -30440,7 +31066,8 @@
             31,
             29,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -30487,7 +31114,8 @@
             6,
             46,
             34
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -30534,7 +31162,8 @@
             10,
             45,
             35
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -30581,7 +31210,8 @@
             32,
             32,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -30628,7 +31258,8 @@
             34,
             34,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -30675,7 +31306,8 @@
             36,
             35,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 34,
@@ -30722,7 +31354,8 @@
             37,
             37,
             32
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 35,
@@ -30769,7 +31402,8 @@
             33,
             33,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 36,
@@ -30816,7 +31450,8 @@
             35,
             36,
             33
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 37,
@@ -30863,7 +31498,8 @@
             38,
             38,
             36
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 38,
@@ -30910,7 +31546,8 @@
             39,
             39,
             37
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 39,
@@ -30957,7 +31594,8 @@
             40,
             41,
             38
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 40,
@@ -31004,7 +31642,8 @@
             41,
             42,
             39
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 41,
@@ -31051,7 +31690,8 @@
             43,
             44,
             41
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 42,
@@ -31098,7 +31738,8 @@
             7,
             51,
             42
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 43,
@@ -31145,7 +31786,8 @@
             11,
             50,
             43
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 44,
@@ -31192,7 +31834,8 @@
             44,
             47,
             44
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 45,
@@ -31239,7 +31882,8 @@
             45,
             48,
             45
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 46,
@@ -31286,7 +31930,8 @@
             46,
             52,
             46
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 47,
@@ -31333,7 +31978,8 @@
             48,
             10,
             48
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 48,
@@ -31380,7 +32026,8 @@
             47,
             9,
             47
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 49,
@@ -31427,7 +32074,8 @@
             50,
             8,
             49
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 50,
@@ -31474,7 +32122,8 @@
             51,
             11,
             51
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 51,
@@ -31521,7 +32170,8 @@
             49,
             15,
             50
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 52,
@@ -31568,7 +32218,8 @@
             52,
             7,
             52
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 53,
@@ -31615,11 +32266,11 @@
             42,
             43,
             40
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00 00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 50,
@@ -31670,7 +32321,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -31717,7 +32369,8 @@
             10,
             7,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -31764,7 +32417,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -31811,7 +32465,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -31858,7 +32513,8 @@
             3,
             14,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -31905,7 +32561,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -31952,7 +32609,8 @@
             5,
             2,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -31999,7 +32657,8 @@
             6,
             18,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -32046,7 +32705,8 @@
             7,
             19,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -32093,7 +32753,8 @@
             8,
             5,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -32140,7 +32801,8 @@
             9,
             6,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -32187,7 +32849,8 @@
             11,
             8,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -32234,7 +32897,8 @@
             12,
             10,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -32281,7 +32945,8 @@
             13,
             9,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -32328,7 +32993,8 @@
             14,
             11,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -32375,7 +33041,8 @@
             15,
             12,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -32422,7 +33089,8 @@
             16,
             13,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -32469,7 +33137,8 @@
             17,
             15,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -32516,7 +33185,8 @@
             18,
             16,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -32563,11 +33233,11 @@
             19,
             17,
             19
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 51,
@@ -32618,7 +33288,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -32665,11 +33336,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 52,
@@ -32720,7 +33391,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -32767,7 +33439,8 @@
             11,
             24,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -32814,7 +33487,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -32861,7 +33535,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -32908,7 +33583,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -32955,7 +33631,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -33002,7 +33679,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -33049,7 +33727,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -33096,7 +33775,8 @@
             7,
             10,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -33143,7 +33823,8 @@
             8,
             11,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -33190,7 +33871,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -33237,7 +33919,8 @@
             12,
             22,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -33284,7 +33967,8 @@
             13,
             8,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -33331,7 +34015,8 @@
             14,
             12,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -33378,7 +34063,8 @@
             15,
             13,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -33425,7 +34111,8 @@
             16,
             14,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -33472,7 +34159,8 @@
             17,
             15,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -33519,7 +34207,8 @@
             18,
             16,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -33566,7 +34255,8 @@
             19,
             17,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -33613,7 +34303,8 @@
             20,
             18,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -33660,7 +34351,8 @@
             21,
             20,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -33707,7 +34399,8 @@
             22,
             21,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -33754,7 +34447,8 @@
             24,
             25,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -33801,7 +34495,8 @@
             25,
             19,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -33848,7 +34543,8 @@
             10,
             23,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -33895,11 +34591,11 @@
             23,
             7,
             23
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 64,
@@ -33950,7 +34646,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -33997,7 +34694,8 @@
             11,
             9,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -34044,7 +34742,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -34091,7 +34790,8 @@
             2,
             4,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -34138,7 +34838,8 @@
             3,
             5,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -34185,7 +34886,8 @@
             4,
             12,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -34232,7 +34934,8 @@
             5,
             10,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -34279,7 +34982,8 @@
             6,
             3,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -34326,7 +35030,8 @@
             7,
             6,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -34373,7 +35078,8 @@
             8,
             7,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -34420,7 +35126,8 @@
             9,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -34467,7 +35174,8 @@
             10,
             11,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -34514,11 +35222,11 @@
             12,
             2,
             12
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 65,
@@ -34569,7 +35277,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -34616,7 +35325,8 @@
             6,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -34663,7 +35373,8 @@
             3,
             5,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -34710,7 +35421,8 @@
             7,
             6,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -34757,7 +35469,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -34804,7 +35517,8 @@
             1,
             8,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -34851,7 +35565,8 @@
             5,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -34898,7 +35613,8 @@
             8,
             2,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -34945,11 +35661,11 @@
             2,
             3,
             8
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 66,
@@ -35000,7 +35716,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -35047,7 +35764,8 @@
             8,
             2,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -35094,7 +35812,8 @@
             3,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -35141,7 +35860,8 @@
             4,
             5,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -35188,7 +35908,8 @@
             2,
             6,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -35235,7 +35956,8 @@
             1,
             3,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -35282,7 +36004,8 @@
             6,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -35329,7 +36052,8 @@
             5,
             9,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -35376,7 +36100,8 @@
             7,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -35423,11 +36148,11 @@
             9,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 67,
@@ -35478,7 +36203,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -35525,7 +36251,8 @@
             2,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -35572,7 +36299,8 @@
             1,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -35619,11 +36347,11 @@
             3,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 68,
@@ -35674,7 +36402,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -35721,7 +36450,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -35768,7 +36498,8 @@
             3,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -35815,11 +36546,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 69,
@@ -35870,7 +36601,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -35917,11 +36649,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 70,
@@ -35972,7 +36704,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -36019,7 +36752,8 @@
             21,
             23,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -36066,7 +36800,8 @@
             14,
             22,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -36113,7 +36848,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -36160,7 +36896,8 @@
             12,
             15,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -36207,7 +36944,8 @@
             26,
             5,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -36254,7 +36992,8 @@
             24,
             3,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -36301,7 +37040,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -36348,7 +37088,8 @@
             3,
             8,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -36395,7 +37136,8 @@
             4,
             7,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -36442,7 +37184,8 @@
             5,
             26,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -36489,7 +37232,8 @@
             28,
             28,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -36536,7 +37280,8 @@
             6,
             9,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -36583,7 +37328,8 @@
             7,
             10,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -36630,7 +37376,8 @@
             8,
             11,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -36677,7 +37424,8 @@
             9,
             12,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -36724,7 +37472,8 @@
             10,
             13,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -36771,7 +37520,8 @@
             11,
             14,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -36818,7 +37568,8 @@
             13,
             16,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -36865,7 +37616,8 @@
             15,
             17,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -36912,7 +37664,8 @@
             16,
             18,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -36959,7 +37712,8 @@
             18,
             19,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -37006,7 +37760,8 @@
             19,
             20,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -37053,7 +37808,8 @@
             20,
             21,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -37100,7 +37856,8 @@
             22,
             24,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -37147,7 +37904,8 @@
             17,
             27,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -37194,7 +37952,8 @@
             23,
             25,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -37241,7 +38000,8 @@
             25,
             4,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -37288,11 +38048,11 @@
             27,
             6,
             27
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 71,
@@ -37343,7 +38103,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -37390,7 +38151,8 @@
             20,
             7,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -37437,7 +38199,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -37484,7 +38247,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -37531,7 +38295,8 @@
             3,
             6,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -37578,7 +38343,8 @@
             4,
             10,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -37625,7 +38391,8 @@
             5,
             11,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -37672,7 +38439,8 @@
             6,
             12,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -37719,7 +38487,8 @@
             7,
             13,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -37766,7 +38535,8 @@
             8,
             14,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -37813,7 +38583,8 @@
             9,
             15,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -37860,7 +38631,8 @@
             10,
             16,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -37907,7 +38679,8 @@
             11,
             17,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -37954,7 +38727,8 @@
             12,
             18,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -38001,7 +38775,8 @@
             14,
             19,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -38048,7 +38823,8 @@
             15,
             20,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -38095,7 +38871,8 @@
             13,
             21,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -38142,7 +38919,8 @@
             16,
             3,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -38189,7 +38967,8 @@
             17,
             4,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -38236,7 +39015,8 @@
             18,
             5,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -38283,7 +39063,8 @@
             19,
             9,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -38330,11 +39111,11 @@
             21,
             8,
             21
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 72,
@@ -38385,7 +39166,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -38432,11 +39214,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 73,
@@ -38487,7 +39269,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -38534,7 +39317,8 @@
             11,
             10,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -38581,7 +39365,8 @@
             1,
             11,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -38628,7 +39413,8 @@
             2,
             14,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -38675,7 +39461,8 @@
             10,
             9,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -38722,7 +39509,8 @@
             4,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -38769,7 +39557,8 @@
             12,
             12,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -38816,7 +39605,8 @@
             5,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -38863,7 +39653,8 @@
             3,
             4,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -38910,7 +39701,8 @@
             9,
             8,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -38957,7 +39749,8 @@
             8,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -39004,7 +39797,8 @@
             6,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -39051,7 +39845,8 @@
             7,
             13,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -39098,7 +39893,8 @@
             14,
             1,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -39145,11 +39941,11 @@
             13,
             3,
             13
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 74,
@@ -39200,7 +39996,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -39247,7 +40044,8 @@
             2,
             1,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -39294,7 +40092,8 @@
             3,
             4,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -39341,7 +40140,8 @@
             5,
             6,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -39388,7 +40188,8 @@
             6,
             3,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -39435,7 +40236,8 @@
             7,
             2,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -39482,7 +40284,8 @@
             1,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -39529,11 +40332,11 @@
             4,
             5,
             3
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 75,
@@ -39584,7 +40387,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -39631,11 +40435,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 76,
@@ -39686,7 +40490,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -39733,7 +40538,8 @@
             19,
             15,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -39780,7 +40586,8 @@
             8,
             6,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -39827,7 +40634,8 @@
             11,
             12,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -39874,7 +40682,8 @@
             6,
             3,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -39921,7 +40730,8 @@
             1,
             11,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -39968,7 +40778,8 @@
             16,
             13,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -40015,7 +40826,8 @@
             17,
             20,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -40062,7 +40874,8 @@
             12,
             19,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -40109,7 +40922,8 @@
             9,
             7,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -40156,7 +40970,8 @@
             14,
             8,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -40203,7 +41018,8 @@
             15,
             10,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -40250,7 +41066,8 @@
             10,
             16,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -40297,7 +41114,8 @@
             3,
             17,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -40344,7 +41162,8 @@
             4,
             14,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -40391,7 +41210,8 @@
             2,
             18,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -40438,7 +41258,8 @@
             13,
             9,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -40485,7 +41306,8 @@
             18,
             4,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -40532,7 +41354,8 @@
             20,
             2,
             5
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 26,
@@ -40579,7 +41402,8 @@
             7,
             5,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -40626,11 +41450,11 @@
             5,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 04 00"
+      "divisionsPatch": []
     },
     {
       "code": 77,
@@ -40681,7 +41505,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -40728,7 +41553,8 @@
             14,
             7,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -40775,7 +41601,8 @@
             1,
             26,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -40822,7 +41649,8 @@
             3,
             1,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -40869,7 +41697,8 @@
             4,
             16,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -40916,7 +41745,8 @@
             5,
             14,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -40963,7 +41793,8 @@
             6,
             3,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -41010,7 +41841,8 @@
             7,
             2,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -41057,7 +41889,8 @@
             8,
             24,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -41104,7 +41937,8 @@
             9,
             25,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -41151,7 +41985,8 @@
             10,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -41198,7 +42033,8 @@
             11,
             23,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -41245,7 +42081,8 @@
             2,
             4,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -41292,7 +42129,8 @@
             15,
             9,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -41339,7 +42177,8 @@
             16,
             10,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -41386,7 +42225,8 @@
             17,
             11,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -41433,7 +42273,8 @@
             20,
             27,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -41480,7 +42321,8 @@
             21,
             15,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -41527,7 +42369,8 @@
             22,
             6,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -41574,7 +42417,8 @@
             23,
             17,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -41621,7 +42465,8 @@
             24,
             19,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -41668,7 +42513,8 @@
             25,
             18,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -41715,7 +42561,8 @@
             27,
             21,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -41762,7 +42609,8 @@
             12,
             5,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -41809,7 +42657,8 @@
             19,
             13,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -41856,7 +42705,8 @@
             13,
             22,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -41903,7 +42753,8 @@
             26,
             20,
             25
-          ]
+          ],
+          "eshopLock": false
         }
       ],
       "divisionsPatch": [
@@ -41940,8 +42791,7 @@
           "latitude": 63210,
           "longitude": 8233
         }
-      ],
-      "tail": "00 00 00 00"
+      ]
     },
     {
       "code": 78,
@@ -41992,7 +42842,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -42039,7 +42890,8 @@
             4,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -42086,7 +42938,8 @@
             8,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -42133,7 +42986,8 @@
             1,
             2,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -42180,7 +43034,8 @@
             3,
             1,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -42227,7 +43082,8 @@
             5,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -42274,7 +43130,8 @@
             6,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -42321,7 +43178,8 @@
             7,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -42368,7 +43226,8 @@
             9,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -42415,7 +43274,8 @@
             2,
             9,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -42462,7 +43322,8 @@
             11,
             14,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -42509,7 +43370,8 @@
             10,
             10,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -42556,7 +43418,8 @@
             12,
             11,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -42603,7 +43466,8 @@
             13,
             12,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -42650,7 +43514,8 @@
             14,
             13,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -42697,7 +43562,8 @@
             15,
             16,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -42744,11 +43610,11 @@
             16,
             15,
             16
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 79,
@@ -42799,7 +43665,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -42846,7 +43713,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -42893,7 +43761,8 @@
             6,
             10,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -42940,7 +43809,8 @@
             9,
             11,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -42987,7 +43857,8 @@
             2,
             6,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -43034,7 +43905,8 @@
             11,
             2,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -43081,7 +43953,8 @@
             5,
             12,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -43128,7 +44001,8 @@
             8,
             5,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -43175,7 +44049,8 @@
             4,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -43222,7 +44097,8 @@
             12,
             7,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -43269,7 +44145,8 @@
             3,
             13,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -43316,7 +44193,8 @@
             13,
             9,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -43363,7 +44241,8 @@
             7,
             3,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -43410,11 +44289,11 @@
             10,
             4,
             13
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 80,
@@ -43465,7 +44344,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -43512,7 +44392,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -43559,7 +44440,8 @@
             1,
             2,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -43606,7 +44488,8 @@
             2,
             1,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -43653,7 +44536,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -43700,7 +44584,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -43747,7 +44632,8 @@
             6,
             18,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -43794,7 +44680,8 @@
             7,
             15,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -43841,7 +44728,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -43888,7 +44776,8 @@
             9,
             16,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -43935,7 +44824,8 @@
             10,
             17,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -43982,7 +44872,8 @@
             11,
             20,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -44029,7 +44920,8 @@
             12,
             10,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -44076,7 +44968,8 @@
             13,
             11,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -44123,7 +45016,8 @@
             14,
             12,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -44170,7 +45064,8 @@
             15,
             19,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -44217,7 +45112,8 @@
             16,
             13,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -44264,7 +45160,8 @@
             17,
             14,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -44311,7 +45208,8 @@
             18,
             6,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -44358,7 +45256,8 @@
             19,
             7,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -44405,11 +45304,11 @@
             20,
             9,
             20
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 81,
@@ -44460,7 +45359,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -44507,11 +45407,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 82,
@@ -44562,7 +45462,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -44609,7 +45510,8 @@
             6,
             3,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -44656,7 +45558,8 @@
             1,
             5,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -44703,7 +45606,8 @@
             2,
             4,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -44750,7 +45654,8 @@
             3,
             9,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -44797,7 +45702,8 @@
             4,
             10,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -44844,7 +45750,8 @@
             5,
             2,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -44891,7 +45798,8 @@
             7,
             1,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -44938,7 +45846,8 @@
             8,
             6,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -44985,7 +45894,8 @@
             9,
             7,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -45032,7 +45942,8 @@
             10,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -45079,7 +45990,8 @@
             11,
             12,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -45126,7 +46038,8 @@
             12,
             14,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -45173,7 +46086,8 @@
             13,
             13,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -45220,7 +46134,8 @@
             14,
             15,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -45267,7 +46182,8 @@
             15,
             11,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -45314,7 +46230,8 @@
             16,
             16,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -45361,7 +46278,8 @@
             17,
             17,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -45408,7 +46326,8 @@
             18,
             18,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -45455,7 +46374,8 @@
             19,
             19,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -45502,7 +46422,8 @@
             20,
             20,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -45549,7 +46470,8 @@
             21,
             21,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -45596,7 +46518,8 @@
             22,
             22,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -45643,7 +46566,8 @@
             23,
             24,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -45690,7 +46614,8 @@
             24,
             26,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -45737,7 +46662,8 @@
             25,
             25,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 34,
@@ -45784,11 +46710,11 @@
             26,
             23,
             25
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 83,
@@ -45839,7 +46765,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -45886,7 +46813,8 @@
             8,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -45933,7 +46861,8 @@
             19,
             4,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -45980,7 +46909,8 @@
             13,
             13,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -46027,7 +46957,8 @@
             9,
             9,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -46074,7 +47005,8 @@
             10,
             10,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -46121,7 +47053,8 @@
             17,
             17,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -46168,7 +47101,8 @@
             20,
             5,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -46215,7 +47149,8 @@
             7,
             19,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -46262,7 +47197,8 @@
             6,
             20,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -46309,7 +47245,8 @@
             16,
             16,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -46356,7 +47293,8 @@
             18,
             18,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -46403,7 +47341,8 @@
             11,
             11,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -46450,7 +47389,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -46497,7 +47437,8 @@
             12,
             12,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -46544,7 +47485,8 @@
             5,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -46591,7 +47533,8 @@
             2,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -46638,7 +47581,8 @@
             3,
             3,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -46685,7 +47629,8 @@
             4,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -46732,7 +47677,8 @@
             15,
             15,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -46779,11 +47725,11 @@
             14,
             14,
             15
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 84,
@@ -46834,7 +47780,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -46881,11 +47828,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 85,
@@ -46936,7 +47883,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -46983,7 +47931,8 @@
             5,
             4,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -47030,7 +47979,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -47077,7 +48027,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -47124,7 +48075,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -47171,7 +48123,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -47218,7 +48171,8 @@
             6,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -47265,7 +48219,8 @@
             7,
             6,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -47312,7 +48267,8 @@
             8,
             9,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -47359,7 +48315,8 @@
             9,
             10,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -47406,11 +48363,11 @@
             10,
             8,
             10
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 86,
@@ -47461,7 +48418,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -47508,11 +48466,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 87,
@@ -47563,7 +48521,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -47610,7 +48569,8 @@
             10,
             2,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -47657,7 +48617,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -47704,7 +48665,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -47751,7 +48713,8 @@
             3,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -47798,7 +48761,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -47845,7 +48809,8 @@
             5,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -47892,7 +48857,8 @@
             6,
             10,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -47939,7 +48905,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -47986,7 +48953,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -48033,11 +49001,11 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 88,
@@ -48088,7 +49056,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -48135,11 +49104,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 89,
@@ -48190,7 +49159,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -48237,11 +49207,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 90,
@@ -48292,7 +49262,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -48339,11 +49310,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 91,
@@ -48394,7 +49365,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -48441,11 +49413,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 92,
@@ -48496,7 +49468,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -48543,11 +49516,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 93,
@@ -48598,7 +49571,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -48645,11 +49619,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 94,
@@ -48700,7 +49674,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -48747,7 +49722,8 @@
             8,
             7,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -48794,7 +49770,8 @@
             2,
             3,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -48841,7 +49818,8 @@
             3,
             10,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -48888,7 +49866,8 @@
             4,
             11,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -48935,7 +49914,8 @@
             6,
             1,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -48982,7 +49962,8 @@
             5,
             2,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -49029,7 +50010,8 @@
             9,
             5,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -49076,7 +50058,8 @@
             1,
             8,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -49123,7 +50106,8 @@
             10,
             6,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -49170,7 +50154,8 @@
             7,
             12,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -49217,7 +50202,8 @@
             11,
             9,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -49264,11 +50250,11 @@
             12,
             4,
             12
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 95,
@@ -49319,7 +50305,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -49366,7 +50353,8 @@
             16,
             2,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -49413,7 +50401,8 @@
             1,
             9,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -49460,7 +50449,8 @@
             2,
             1,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -49507,7 +50497,8 @@
             3,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -49554,7 +50545,8 @@
             11,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -49601,7 +50593,8 @@
             6,
             16,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -49648,7 +50641,8 @@
             7,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -49695,7 +50689,8 @@
             9,
             7,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -49742,7 +50737,8 @@
             10,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -49789,7 +50785,8 @@
             12,
             11,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -49836,7 +50833,8 @@
             13,
             12,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -49883,7 +50881,8 @@
             15,
             14,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -49930,7 +50929,8 @@
             5,
             3,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -49977,7 +50977,8 @@
             4,
             15,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -50024,7 +51025,8 @@
             8,
             5,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -50071,11 +51073,11 @@
             14,
             13,
             13
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 96,
@@ -50126,7 +51128,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -50173,7 +51176,8 @@
             11,
             9,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -50220,7 +51224,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -50267,7 +51272,8 @@
             2,
             20,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -50314,7 +51320,8 @@
             3,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -50361,7 +51368,8 @@
             4,
             15,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -50408,7 +51416,8 @@
             5,
             16,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -50455,7 +51464,8 @@
             6,
             17,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -50502,7 +51512,8 @@
             7,
             5,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -50549,7 +51560,8 @@
             9,
             7,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -50596,7 +51608,8 @@
             8,
             6,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -50643,7 +51656,8 @@
             10,
             8,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -50690,7 +51704,8 @@
             13,
             10,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -50737,7 +51752,8 @@
             14,
             12,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -50784,7 +51800,8 @@
             15,
             11,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -50831,7 +51848,8 @@
             17,
             13,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -50878,7 +51896,8 @@
             18,
             14,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -50925,7 +51944,8 @@
             19,
             3,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -50972,7 +51992,8 @@
             20,
             4,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -51019,7 +52040,8 @@
             12,
             19,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -51066,11 +52088,11 @@
             16,
             18,
             16
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 97,
@@ -51121,7 +52143,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -51168,7 +52191,8 @@
             7,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -51215,7 +52239,8 @@
             1,
             10,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -51262,7 +52287,8 @@
             2,
             4,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -51309,7 +52335,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -51356,7 +52383,8 @@
             5,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -51403,7 +52431,8 @@
             6,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -51450,7 +52479,8 @@
             9,
             9,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -51497,7 +52527,8 @@
             8,
             11,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -51544,7 +52575,8 @@
             15,
             12,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -51591,7 +52623,8 @@
             10,
             13,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -51638,7 +52671,8 @@
             11,
             14,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -51685,7 +52719,8 @@
             14,
             16,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -51732,7 +52767,8 @@
             13,
             15,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -51779,7 +52815,8 @@
             16,
             1,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -51826,7 +52863,8 @@
             3,
             2,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -51873,11 +52911,11 @@
             12,
             3,
             16
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 98,
@@ -51928,7 +52966,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -51975,7 +53014,8 @@
             12,
             13,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -52022,7 +53062,8 @@
             13,
             14,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -52069,7 +53110,8 @@
             1,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -52116,7 +53158,8 @@
             2,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -52163,7 +53206,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -52210,7 +53254,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -52257,7 +53302,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -52304,7 +53350,8 @@
             6,
             10,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -52351,7 +53398,8 @@
             7,
             11,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -52398,7 +53446,8 @@
             8,
             20,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -52445,7 +53494,8 @@
             9,
             19,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -52492,7 +53542,8 @@
             10,
             9,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -52539,7 +53590,8 @@
             11,
             12,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -52586,7 +53638,8 @@
             14,
             15,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -52633,7 +53686,8 @@
             15,
             16,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -52680,7 +53734,8 @@
             16,
             17,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -52727,7 +53782,8 @@
             17,
             18,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -52774,7 +53830,8 @@
             18,
             6,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -52821,7 +53878,8 @@
             19,
             8,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -52868,11 +53926,11 @@
             20,
             7,
             20
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 99,
@@ -52923,7 +53981,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -52970,7 +54029,8 @@
             10,
             11,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -53017,7 +54077,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -53064,7 +54125,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -53111,7 +54173,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -53158,7 +54221,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -53205,7 +54269,8 @@
             5,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -53252,7 +54317,8 @@
             6,
             5,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -53299,7 +54365,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -53346,7 +54413,8 @@
             8,
             9,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -53393,7 +54461,8 @@
             9,
             8,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -53440,7 +54509,8 @@
             11,
             10,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -53487,7 +54557,8 @@
             12,
             25,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -53534,7 +54605,8 @@
             13,
             21,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -53581,7 +54653,8 @@
             14,
             22,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -53628,7 +54701,8 @@
             15,
             24,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -53675,7 +54749,8 @@
             16,
             23,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -53722,7 +54797,8 @@
             17,
             19,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -53769,7 +54845,8 @@
             18,
             18,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -53816,7 +54893,8 @@
             19,
             15,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -53863,7 +54941,8 @@
             20,
             17,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -53910,7 +54989,8 @@
             21,
             16,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -53957,7 +55037,8 @@
             22,
             39,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -54004,7 +55085,8 @@
             23,
             40,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -54051,7 +55133,8 @@
             24,
             41,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -54098,7 +55181,8 @@
             25,
             42,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -54145,7 +55229,8 @@
             26,
             20,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -54192,7 +55277,8 @@
             27,
             26,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -54239,7 +55325,8 @@
             28,
             27,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -54286,7 +55373,8 @@
             29,
             28,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -54333,7 +55421,8 @@
             30,
             29,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -54380,7 +55469,8 @@
             31,
             30,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -54427,7 +55517,8 @@
             32,
             31,
             32
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 34,
@@ -54474,7 +55565,8 @@
             33,
             35,
             33
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 35,
@@ -54521,7 +55613,8 @@
             34,
             32,
             34
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 36,
@@ -54568,7 +55661,8 @@
             35,
             33,
             35
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 37,
@@ -54615,7 +55709,8 @@
             36,
             34,
             36
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 38,
@@ -54662,7 +55757,8 @@
             37,
             36,
             37
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 39,
@@ -54709,7 +55805,8 @@
             38,
             37,
             38
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 40,
@@ -54756,7 +55853,8 @@
             39,
             38,
             39
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 41,
@@ -54803,7 +55901,8 @@
             40,
             14,
             40
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 42,
@@ -54850,7 +55949,8 @@
             41,
             12,
             41
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 43,
@@ -54897,11 +55997,11 @@
             42,
             13,
             42
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00 00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 100,
@@ -54952,7 +56052,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -54999,7 +56100,8 @@
             43,
             30,
             43
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -55046,7 +56148,8 @@
             1,
             44,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -55093,7 +56196,8 @@
             2,
             45,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -55140,7 +56244,8 @@
             3,
             1,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -55187,7 +56292,8 @@
             4,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -55234,7 +56340,8 @@
             5,
             3,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -55281,7 +56388,8 @@
             6,
             4,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -55328,7 +56436,8 @@
             7,
             46,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -55375,7 +56484,8 @@
             8,
             5,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -55422,7 +56532,8 @@
             9,
             6,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -55469,7 +56580,8 @@
             10,
             47,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -55516,7 +56628,8 @@
             15,
             79,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -55563,7 +56676,8 @@
             16,
             78,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -55610,7 +56724,8 @@
             17,
             81,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -55657,7 +56772,8 @@
             18,
             80,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -55704,7 +56820,8 @@
             19,
             48,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -55751,7 +56868,8 @@
             21,
             49,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -55798,7 +56916,8 @@
             22,
             14,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -55845,7 +56964,8 @@
             23,
             13,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -55892,7 +57012,8 @@
             11,
             15,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -55939,7 +57060,8 @@
             24,
             16,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -55986,7 +57108,8 @@
             13,
             50,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -56033,7 +57156,8 @@
             25,
             17,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -56080,7 +57204,8 @@
             26,
             18,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -56127,7 +57252,8 @@
             27,
             19,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 34,
@@ -56174,7 +57300,8 @@
             14,
             51,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 35,
@@ -56221,7 +57348,8 @@
             28,
             20,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 36,
@@ -56268,7 +57396,8 @@
             29,
             76,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 37,
@@ -56315,7 +57444,8 @@
             12,
             59,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 38,
@@ -56362,7 +57492,8 @@
             30,
             77,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 39,
@@ -56409,7 +57540,8 @@
             31,
             21,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 40,
@@ -56456,7 +57588,8 @@
             32,
             52,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 41,
@@ -56503,7 +57636,8 @@
             33,
             22,
             32
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 42,
@@ -56550,7 +57684,8 @@
             34,
             23,
             33
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 43,
@@ -56597,7 +57732,8 @@
             35,
             24,
             34
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 44,
@@ -56644,7 +57780,8 @@
             36,
             25,
             35
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 45,
@@ -56691,7 +57828,8 @@
             37,
             26,
             36
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 46,
@@ -56738,7 +57876,8 @@
             38,
             27,
             37
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 47,
@@ -56785,7 +57924,8 @@
             39,
             28,
             38
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 48,
@@ -56832,7 +57972,8 @@
             40,
             29,
             39
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 49,
@@ -56879,7 +58020,8 @@
             41,
             53,
             40
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 50,
@@ -56926,7 +58068,8 @@
             42,
             54,
             41
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 51,
@@ -56973,7 +58116,8 @@
             44,
             31,
             42
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 52,
@@ -57020,7 +58164,8 @@
             45,
             32,
             44
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 53,
@@ -57067,7 +58212,8 @@
             46,
             33,
             45
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 54,
@@ -57114,7 +58260,8 @@
             47,
             34,
             46
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 55,
@@ -57161,7 +58308,8 @@
             48,
             35,
             48
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 56,
@@ -57208,7 +58356,8 @@
             49,
             36,
             49
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 57,
@@ -57255,7 +58404,8 @@
             50,
             37,
             50
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 58,
@@ -57302,7 +58452,8 @@
             52,
             38,
             52
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 59,
@@ -57349,7 +58500,8 @@
             51,
             39,
             51
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 60,
@@ -57396,7 +58548,8 @@
             54,
             40,
             53
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 61,
@@ -57443,7 +58596,8 @@
             55,
             41,
             54
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 62,
@@ -57490,7 +58644,8 @@
             56,
             42,
             55
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 63,
@@ -57537,7 +58692,8 @@
             57,
             43,
             56
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 64,
@@ -57584,7 +58740,8 @@
             60,
             60,
             57
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 65,
@@ -57631,7 +58788,8 @@
             59,
             61,
             58
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 66,
@@ -57678,7 +58836,8 @@
             20,
             55,
             59
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 67,
@@ -57725,7 +58884,8 @@
             61,
             65,
             60
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 68,
@@ -57772,7 +58932,8 @@
             62,
             62,
             61
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 69,
@@ -57819,7 +58980,8 @@
             63,
             63,
             64
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 70,
@@ -57866,7 +59028,8 @@
             64,
             64,
             62
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 71,
@@ -57913,7 +59076,8 @@
             53,
             56,
             47
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 72,
@@ -57960,7 +59124,8 @@
             65,
             67,
             63
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 73,
@@ -58007,7 +59172,8 @@
             66,
             68,
             65
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 74,
@@ -58054,7 +59220,8 @@
             67,
             66,
             66
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 75,
@@ -58101,7 +59268,8 @@
             68,
             69,
             67
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 76,
@@ -58148,7 +59316,8 @@
             69,
             57,
             68
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 77,
@@ -58195,7 +59364,8 @@
             71,
             71,
             69
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 78,
@@ -58242,7 +59412,8 @@
             73,
             72,
             70
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 79,
@@ -58289,7 +59460,8 @@
             75,
             70,
             72
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 80,
@@ -58336,7 +59508,8 @@
             70,
             73,
             73
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 81,
@@ -58383,7 +59556,8 @@
             74,
             58,
             71
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 82,
@@ -58430,7 +59604,8 @@
             76,
             74,
             74
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 83,
@@ -58477,7 +59652,8 @@
             77,
             75,
             75
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 84,
@@ -58524,7 +59700,8 @@
             78,
             7,
             76
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 85,
@@ -58571,7 +59748,8 @@
             79,
             8,
             77
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 86,
@@ -58618,7 +59796,8 @@
             80,
             9,
             78
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 87,
@@ -58665,7 +59844,8 @@
             81,
             10,
             79
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 88,
@@ -58712,7 +59892,8 @@
             82,
             82,
             80
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 89,
@@ -58759,7 +59940,8 @@
             83,
             83,
             81
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 90,
@@ -58806,7 +59988,8 @@
             58,
             11,
             82
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 91,
@@ -58853,11 +60036,11 @@
             72,
             12,
             83
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00 00 00 00 00 00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 101,
@@ -58908,7 +60091,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -58955,11 +60139,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 102,
@@ -59010,7 +60194,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -59057,7 +60242,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -59104,7 +60290,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -59151,7 +60338,8 @@
             3,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -59198,7 +60386,8 @@
             4,
             5,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -59245,7 +60434,8 @@
             5,
             6,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -59292,7 +60482,8 @@
             6,
             7,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -59339,7 +60530,8 @@
             7,
             8,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -59386,11 +60578,11 @@
             8,
             3,
             8
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 103,
@@ -59441,7 +60633,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -59488,11 +60681,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 104,
@@ -59543,7 +60736,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -59590,7 +60784,8 @@
             5,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -59637,7 +60832,8 @@
             2,
             3,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -59684,7 +60880,8 @@
             1,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -59731,7 +60928,8 @@
             3,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -59778,7 +60976,8 @@
             6,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -59825,7 +61024,8 @@
             4,
             9,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -59872,7 +61072,8 @@
             9,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -59919,7 +61120,8 @@
             8,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -59966,11 +61168,11 @@
             7,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 105,
@@ -60021,7 +61223,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -60068,7 +61271,8 @@
             14,
             12,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -60115,7 +61319,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -60162,7 +61367,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -60209,7 +61415,8 @@
             3,
             3,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -60256,7 +61463,8 @@
             12,
             4,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -60303,7 +61511,8 @@
             4,
             7,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -60350,7 +61559,8 @@
             5,
             8,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -60397,7 +61607,8 @@
             6,
             9,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -60444,7 +61655,8 @@
             7,
             10,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -60491,7 +61703,8 @@
             8,
             11,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -60538,7 +61751,8 @@
             19,
             5,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -60585,7 +61799,8 @@
             10,
             19,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -60632,7 +61847,8 @@
             11,
             6,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -60679,7 +61895,8 @@
             16,
             14,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -60726,7 +61943,8 @@
             17,
             15,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -60773,7 +61991,8 @@
             18,
             18,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -60820,7 +62039,8 @@
             13,
             16,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -60867,7 +62087,8 @@
             9,
             17,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -60914,11 +62135,11 @@
             15,
             13,
             15
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 106,
@@ -60969,7 +62190,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -61016,7 +62238,8 @@
             1,
             3,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -61063,7 +62286,8 @@
             2,
             1,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -61110,7 +62334,8 @@
             3,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -61157,11 +62382,11 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 107,
@@ -61212,7 +62437,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -61259,7 +62485,8 @@
             4,
             17,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -61306,7 +62533,8 @@
             3,
             16,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -61353,7 +62581,8 @@
             21,
             7,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -61400,7 +62629,8 @@
             14,
             21,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -61447,7 +62677,8 @@
             15,
             15,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -61494,7 +62725,8 @@
             17,
             3,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -61541,7 +62773,8 @@
             16,
             18,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -61588,7 +62821,8 @@
             5,
             9,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -61635,7 +62869,8 @@
             18,
             4,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -61682,7 +62917,8 @@
             12,
             14,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -61729,7 +62965,8 @@
             6,
             1,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -61776,7 +63013,8 @@
             8,
             10,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -61823,7 +63061,8 @@
             2,
             8,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -61870,7 +63109,8 @@
             1,
             2,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -61917,7 +63157,8 @@
             13,
             20,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -61964,7 +63205,8 @@
             19,
             5,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -62011,7 +63253,8 @@
             9,
             11,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -62058,7 +63301,8 @@
             11,
             13,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -62105,7 +63349,8 @@
             10,
             12,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -62152,7 +63397,8 @@
             20,
             6,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -62199,11 +63445,11 @@
             7,
             19,
             5
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 108,
@@ -62254,7 +63500,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -62301,7 +63548,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -62348,7 +63596,8 @@
             3,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -62395,7 +63644,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -62442,7 +63692,8 @@
             7,
             21,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -62489,7 +63740,8 @@
             8,
             11,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -62536,7 +63788,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -62583,7 +63836,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -62630,7 +63884,8 @@
             11,
             26,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -62677,7 +63932,8 @@
             12,
             13,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -62724,7 +63980,8 @@
             13,
             14,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -62771,7 +64028,8 @@
             15,
             16,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -62818,7 +64076,8 @@
             16,
             17,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -62865,7 +64124,8 @@
             17,
             24,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -62912,7 +64172,8 @@
             18,
             25,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -62959,7 +64220,8 @@
             19,
             12,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -63006,7 +64268,8 @@
             21,
             19,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -63053,7 +64316,8 @@
             20,
             18,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -63100,7 +64364,8 @@
             22,
             20,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -63147,7 +64412,8 @@
             23,
             7,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -63194,7 +64460,8 @@
             24,
             8,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -63241,7 +64508,8 @@
             25,
             22,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -63288,7 +64556,8 @@
             26,
             23,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -63335,7 +64604,8 @@
             1,
             2,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -63382,7 +64652,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -63429,7 +64700,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -63476,11 +64748,11 @@
             14,
             15,
             14
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 109,
@@ -63531,7 +64803,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -63578,7 +64851,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -63625,7 +64899,8 @@
             40,
             61,
             40
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -63672,7 +64947,8 @@
             41,
             30,
             41
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -63719,7 +64995,8 @@
             21,
             21,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -63766,7 +65043,8 @@
             1,
             2,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -63813,7 +65091,8 @@
             33,
             23,
             33
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -63860,7 +65139,8 @@
             53,
             40,
             53
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -63907,7 +65187,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -63954,7 +65235,8 @@
             26,
             27,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -64001,7 +65283,8 @@
             58,
             48,
             58
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -64048,7 +65331,8 @@
             47,
             32,
             47
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -64095,7 +65379,8 @@
             68,
             72,
             68
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -64142,7 +65427,8 @@
             55,
             45,
             55
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -64189,7 +65475,8 @@
             31,
             79,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -64236,7 +65523,8 @@
             67,
             57,
             67
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -64283,7 +65571,8 @@
             78,
             22,
             78
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -64330,7 +65619,8 @@
             42,
             37,
             42
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -64377,7 +65667,8 @@
             25,
             26,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -64424,7 +65715,8 @@
             14,
             15,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -64471,7 +65763,8 @@
             29,
             77,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -64518,7 +65811,8 @@
             66,
             56,
             66
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -64565,7 +65859,8 @@
             52,
             39,
             52
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -64612,7 +65907,8 @@
             72,
             58,
             72
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -64659,7 +65955,8 @@
             56,
             46,
             56
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -64706,7 +66003,8 @@
             75,
             64,
             75
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 28,
@@ -64753,7 +66051,8 @@
             12,
             13,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -64800,7 +66099,8 @@
             2,
             3,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -64847,7 +66147,8 @@
             73,
             62,
             73
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -64894,7 +66195,8 @@
             49,
             43,
             49
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -64941,7 +66243,8 @@
             64,
             54,
             64
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -64988,7 +66291,8 @@
             54,
             44,
             54
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 34,
@@ -65035,7 +66339,8 @@
             24,
             71,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 35,
@@ -65082,7 +66387,8 @@
             39,
             75,
             39
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 36,
@@ -65129,7 +66435,8 @@
             11,
             4,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 37,
@@ -65176,7 +66483,8 @@
             37,
             68,
             37
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 38,
@@ -65223,7 +66531,8 @@
             57,
             47,
             57
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 39,
@@ -65270,7 +66579,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 40,
@@ -65317,7 +66627,8 @@
             3,
             11,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 41,
@@ -65364,7 +66675,8 @@
             74,
             63,
             74
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 42,
@@ -65411,7 +66723,8 @@
             28,
             76,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 43,
@@ -65458,7 +66771,8 @@
             44,
             34,
             44
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 44,
@@ -65505,7 +66819,8 @@
             63,
             53,
             63
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 45,
@@ -65552,7 +66867,8 @@
             69,
             59,
             69
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 46,
@@ -65599,7 +66915,8 @@
             30,
             78,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 47,
@@ -65646,7 +66963,8 @@
             23,
             70,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 48,
@@ -65693,7 +67011,8 @@
             81,
             29,
             81
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 49,
@@ -65740,7 +67059,8 @@
             80,
             31,
             80
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 50,
@@ -65787,7 +67107,8 @@
             77,
             66,
             77
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 51,
@@ -65834,7 +67155,8 @@
             4,
             1,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 52,
@@ -65881,7 +67203,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 53,
@@ -65928,7 +67251,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 54,
@@ -65975,7 +67299,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 55,
@@ -66022,7 +67347,8 @@
             13,
             14,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 56,
@@ -66069,7 +67395,8 @@
             15,
             12,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 57,
@@ -66116,7 +67443,8 @@
             16,
             16,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 58,
@@ -66163,7 +67491,8 @@
             17,
             17,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 59,
@@ -66210,7 +67539,8 @@
             18,
             18,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 60,
@@ -66257,7 +67587,8 @@
             19,
             19,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 61,
@@ -66304,7 +67635,8 @@
             20,
             20,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 62,
@@ -66351,7 +67683,8 @@
             22,
             69,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 63,
@@ -66398,7 +67731,8 @@
             27,
             28,
             27
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 64,
@@ -66445,7 +67779,8 @@
             32,
             80,
             32
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 65,
@@ -66492,7 +67827,8 @@
             34,
             24,
             34
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 66,
@@ -66539,7 +67875,8 @@
             35,
             25,
             35
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 67,
@@ -66586,7 +67923,8 @@
             36,
             67,
             36
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 68,
@@ -66633,7 +67971,8 @@
             38,
             74,
             38
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 69,
@@ -66680,7 +68019,8 @@
             43,
             33,
             43
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 70,
@@ -66727,7 +68067,8 @@
             45,
             35,
             45
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 71,
@@ -66774,7 +68115,8 @@
             46,
             36,
             46
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 72,
@@ -66821,7 +68163,8 @@
             48,
             38,
             48
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 73,
@@ -66868,7 +68211,8 @@
             50,
             41,
             50
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 74,
@@ -66915,7 +68259,8 @@
             51,
             42,
             51
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 75,
@@ -66962,7 +68307,8 @@
             59,
             49,
             59
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 76,
@@ -67009,7 +68355,8 @@
             60,
             50,
             60
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 77,
@@ -67056,7 +68403,8 @@
             61,
             51,
             61
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 78,
@@ -67103,7 +68451,8 @@
             62,
             52,
             62
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 79,
@@ -67150,7 +68499,8 @@
             65,
             55,
             65
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 80,
@@ -67197,7 +68547,8 @@
             70,
             60,
             70
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 81,
@@ -67244,7 +68595,8 @@
             71,
             73,
             71
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 82,
@@ -67291,7 +68643,8 @@
             76,
             65,
             76
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 83,
@@ -67338,11 +68691,11 @@
             79,
             81,
             79
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00 00 00 00 00 00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 110,
@@ -67393,7 +68746,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -67440,7 +68794,8 @@
             3,
             1,
             3
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 4,
@@ -67487,7 +68842,8 @@
             1,
             11,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -67534,7 +68890,8 @@
             10,
             10,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -67581,7 +68938,8 @@
             4,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         }
       ],
       "divisionsPatch": [
@@ -67882,8 +69240,7 @@
           "latitude": 9255,
           "longitude": 65513
         }
-      ],
-      "tail": "02 00 00 00"
+      ]
     },
     {
       "code": 111,
@@ -67934,7 +69291,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -67981,11 +69339,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 112,
@@ -68036,7 +69394,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68083,11 +69442,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 113,
@@ -68138,7 +69497,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68185,11 +69545,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 114,
@@ -68240,7 +69600,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68287,11 +69648,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 115,
@@ -68342,7 +69703,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68389,11 +69751,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 116,
@@ -68444,7 +69806,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68491,11 +69854,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 117,
@@ -68546,7 +69909,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68593,11 +69957,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 118,
@@ -68648,7 +70012,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68695,11 +70060,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 119,
@@ -68750,7 +70115,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68797,11 +70163,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 120,
@@ -68852,7 +70218,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -68899,11 +70266,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 121,
@@ -68954,7 +70321,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -69001,11 +70369,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 122,
@@ -69056,7 +70424,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -69103,11 +70472,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 123,
@@ -69158,7 +70527,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -69205,11 +70575,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 124,
@@ -69260,7 +70630,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -69307,11 +70678,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 125,
@@ -69362,7 +70733,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -69409,11 +70781,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 126,
@@ -69464,7 +70836,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -69511,11 +70884,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 127,
@@ -69566,7 +70939,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -69613,11 +70987,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 128,
@@ -69668,7 +71042,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -69715,7 +71090,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -69762,7 +71138,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -69809,7 +71186,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -69856,7 +71234,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -69903,7 +71282,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -69950,7 +71330,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -69997,7 +71378,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -70044,7 +71426,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -70091,7 +71474,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -70138,7 +71522,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -70185,7 +71570,8 @@
             11,
             11,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -70232,7 +71618,8 @@
             13,
             13,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -70279,7 +71666,8 @@
             14,
             14,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -70326,7 +71714,8 @@
             15,
             15,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -70373,7 +71762,8 @@
             16,
             16,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -70420,7 +71810,8 @@
             19,
             19,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -70467,7 +71858,8 @@
             20,
             20,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -70514,7 +71906,8 @@
             21,
             21,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -70561,7 +71954,8 @@
             22,
             22,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -70608,7 +72002,8 @@
             23,
             23,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -70655,7 +72050,8 @@
             24,
             24,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -70702,7 +72098,8 @@
             25,
             25,
             25
-          ]
+          ],
+          "eshopLock": false
         }
       ],
       "divisionsPatch": [
@@ -70805,8 +72202,7 @@
           "latitude": 4118,
           "longitude": 21909
         }
-      ],
-      "tail": "00 00 00 00"
+      ]
     },
     {
       "code": 136,
@@ -70857,7 +72253,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -70904,7 +72301,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -70951,7 +72349,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -70998,7 +72397,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -71045,7 +72445,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -71092,7 +72493,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -71139,7 +72541,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -71186,7 +72589,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -71233,7 +72637,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -71280,7 +72685,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -71327,7 +72733,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -71374,7 +72781,8 @@
             11,
             11,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -71421,7 +72829,8 @@
             12,
             12,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -71468,7 +72877,8 @@
             13,
             13,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -71515,7 +72925,8 @@
             14,
             14,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -71562,7 +72973,8 @@
             15,
             15,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -71609,11 +73021,11 @@
             16,
             16,
             16
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 144,
@@ -71664,7 +73076,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -71711,11 +73124,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 145,
@@ -71766,7 +73179,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         }
       ],
       "divisionsPatch": [
@@ -71803,8 +73217,7 @@
           "latitude": 4044,
           "longitude": 20680
         }
-      ],
-      "tail": "00 00 00 00"
+      ]
     },
     {
       "code": 153,
@@ -71855,7 +73268,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -71902,11 +73316,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 156,
@@ -71957,7 +73371,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -72004,7 +73419,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -72051,7 +73467,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -72098,7 +73515,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -72145,7 +73563,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -72192,7 +73611,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -72239,7 +73659,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -72286,7 +73707,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -72333,7 +73755,8 @@
             10,
             9,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -72380,7 +73803,8 @@
             11,
             10,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -72427,7 +73851,8 @@
             9,
             11,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -72474,7 +73899,8 @@
             14,
             14,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -72521,7 +73947,8 @@
             15,
             15,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -72568,7 +73995,8 @@
             16,
             16,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -72615,7 +74043,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -72662,7 +74091,8 @@
             13,
             13,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -72709,11 +74139,11 @@
             12,
             12,
             12
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 160,
@@ -72764,7 +74194,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -72811,7 +74242,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -72858,7 +74290,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -72905,7 +74338,8 @@
             3,
             3,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -72952,7 +74386,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -72999,7 +74434,8 @@
             5,
             5,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -73046,7 +74482,8 @@
             6,
             6,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -73093,7 +74530,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -73140,7 +74578,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -73187,7 +74626,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -73234,7 +74674,8 @@
             10,
             10,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -73281,7 +74722,8 @@
             11,
             11,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -73328,7 +74770,8 @@
             12,
             12,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -73375,7 +74818,8 @@
             13,
             13,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 15,
@@ -73422,7 +74866,8 @@
             14,
             14,
             14
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 16,
@@ -73469,7 +74914,8 @@
             15,
             15,
             15
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 17,
@@ -73516,7 +74962,8 @@
             16,
             16,
             16
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 18,
@@ -73563,7 +75010,8 @@
             17,
             17,
             17
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 19,
@@ -73610,7 +75058,8 @@
             18,
             18,
             18
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 20,
@@ -73657,7 +75106,8 @@
             19,
             19,
             19
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 21,
@@ -73704,7 +75154,8 @@
             20,
             20,
             20
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 22,
@@ -73751,7 +75202,8 @@
             21,
             21,
             21
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 23,
@@ -73798,7 +75250,8 @@
             22,
             22,
             22
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 24,
@@ -73845,7 +75298,8 @@
             23,
             23,
             23
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 25,
@@ -73892,7 +75346,8 @@
             24,
             24,
             24
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 26,
@@ -73939,7 +75394,8 @@
             25,
             25,
             25
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 27,
@@ -73986,7 +75442,8 @@
             26,
             26,
             26
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 29,
@@ -74033,7 +75490,8 @@
             28,
             28,
             28
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 30,
@@ -74080,7 +75538,8 @@
             29,
             29,
             29
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 31,
@@ -74127,7 +75586,8 @@
             30,
             30,
             30
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 32,
@@ -74174,7 +75634,8 @@
             31,
             31,
             31
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 33,
@@ -74221,7 +75682,8 @@
             32,
             32,
             32
-          ]
+          ],
+          "eshopLock": false
         }
       ],
       "divisionsPatch": [
@@ -74324,8 +75786,7 @@
           "latitude": 4089,
           "longitude": 20807
         }
-      ],
-      "tail": "00 00 00 00 00 00 00 00"
+      ]
     },
     {
       "code": 168,
@@ -74376,7 +75837,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -74423,7 +75885,8 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -74470,7 +75933,8 @@
             2,
             2,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -74517,7 +75981,8 @@
             6,
             7,
             4
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -74564,7 +76029,8 @@
             5,
             4,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -74611,7 +76077,8 @@
             3,
             3,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -74658,7 +76125,8 @@
             4,
             6,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -74705,11 +76173,11 @@
             7,
             5,
             7
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 169,
@@ -74760,7 +76228,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 2,
@@ -74807,7 +76276,8 @@
             9,
             9,
             9
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 3,
@@ -74854,7 +76324,8 @@
             14,
             1,
             1
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 4,
@@ -74901,7 +76372,8 @@
             1,
             2,
             2
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 5,
@@ -74948,7 +76420,8 @@
             2,
             3,
             3
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 6,
@@ -74995,7 +76468,8 @@
             5,
             33,
             5
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 7,
@@ -75042,7 +76516,8 @@
             7,
             7,
             7
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 8,
@@ -75089,7 +76564,8 @@
             11,
             6,
             11
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 9,
@@ -75136,7 +76612,8 @@
             12,
             31,
             12
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 10,
@@ -75183,7 +76660,8 @@
             13,
             32,
             13
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 12,
@@ -75230,7 +76708,8 @@
             17,
             13,
             16
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 13,
@@ -75277,7 +76756,8 @@
             18,
             14,
             17
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 14,
@@ -75324,7 +76804,8 @@
             20,
             17,
             19
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 15,
@@ -75371,7 +76852,8 @@
             21,
             16,
             20
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 16,
@@ -75418,7 +76900,8 @@
             22,
             18,
             21
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 17,
@@ -75465,7 +76948,8 @@
             16,
             12,
             15
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 18,
@@ -75512,7 +76996,8 @@
             24,
             20,
             23
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 19,
@@ -75559,7 +77044,8 @@
             25,
             21,
             24
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 20,
@@ -75606,7 +77092,8 @@
             27,
             24,
             26
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 21,
@@ -75653,7 +77140,8 @@
             28,
             23,
             27
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 22,
@@ -75700,7 +77188,8 @@
             29,
             25,
             28
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 23,
@@ -75747,7 +77236,8 @@
             31,
             27,
             30
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 24,
@@ -75794,7 +77284,8 @@
             32,
             28,
             31
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 25,
@@ -75841,7 +77332,8 @@
             3,
             11,
             34
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 26,
@@ -75888,7 +77380,8 @@
             30,
             26,
             29
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 28,
@@ -75935,7 +77428,8 @@
             23,
             19,
             22
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 29,
@@ -75982,7 +77476,8 @@
             8,
             8,
             8
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 30,
@@ -76029,7 +77524,8 @@
             10,
             5,
             10
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 31,
@@ -76076,7 +77572,8 @@
             4,
             4,
             4
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 32,
@@ -76123,7 +77620,8 @@
             19,
             15,
             18
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 33,
@@ -76170,7 +77668,8 @@
             33,
             29,
             32
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 34,
@@ -76217,7 +77716,8 @@
             6,
             34,
             6
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 35,
@@ -76264,7 +77764,8 @@
             15,
             10,
             14
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 36,
@@ -76311,7 +77812,8 @@
             34,
             30,
             33
-          ]
+          ],
+          "eshopLock": true
         },
         {
           "division": 37,
@@ -76358,11 +77860,11 @@
             26,
             22,
             25
-          ]
+          ],
+          "eshopLock": true
         }
       ],
-      "divisionsPatch": [],
-      "tail": "FF FF FF FF 07 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 174,
@@ -76413,7 +77915,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 2,
@@ -76460,7 +77963,8 @@
             12,
             12,
             7
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 3,
@@ -76507,7 +78011,8 @@
             4,
             7,
             2
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 4,
@@ -76554,7 +78059,8 @@
             9,
             10,
             5
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 5,
@@ -76601,7 +78107,8 @@
             2,
             13,
             8
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 6,
@@ -76648,7 +78155,8 @@
             11,
             9,
             6
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 7,
@@ -76695,7 +78203,8 @@
             3,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 8,
@@ -76742,7 +78251,8 @@
             6,
             6,
             9
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 9,
@@ -76789,7 +78299,8 @@
             8,
             3,
             11
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 10,
@@ -76836,7 +78347,8 @@
             5,
             11,
             3
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 11,
@@ -76883,7 +78395,8 @@
             10,
             4,
             12
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 12,
@@ -76930,7 +78443,8 @@
             7,
             2,
             10
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 13,
@@ -76977,7 +78491,8 @@
             13,
             5,
             13
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 14,
@@ -77024,11 +78539,11 @@
             1,
             8,
             4
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 184,
@@ -77079,7 +78594,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -77126,11 +78642,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 185,
@@ -77181,7 +78697,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -77228,11 +78745,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     },
     {
       "code": 186,
@@ -77283,7 +78800,8 @@
             0,
             0,
             0
-          ]
+          ],
+          "eshopLock": false
         },
         {
           "division": 1,
@@ -77330,11 +78848,11 @@
             1,
             1,
             1
-          ]
+          ],
+          "eshopLock": false
         }
       ],
-      "divisionsPatch": [],
-      "tail": "00 00 00 00"
+      "divisionsPatch": []
     }
   ]
 }


### PR DESCRIPTION
This bit is set only for the following regions:
 - a cancelled region in Finland
 - a deprecated region ("England") in UK due to introducing its sub division in the list
 - the entire India (confirmed the information about eshop being unavailable there)